### PR TITLE
Fix/video urls perspectives timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsb-100",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "proxy": "https://gsb100.dhlab.lu",
   "dependencies": {

--- a/src/components/TimelineVideo/TimelineVideo.js
+++ b/src/components/TimelineVideo/TimelineVideo.js
@@ -8,7 +8,12 @@ import styles from './TimelineVideo.module.scss'
 
 const PeriodVideo = React.forwardRef(({ id, title }, ref) => {
   const [story] = useCacheStory(id)
-  const videoUrl = story.contents?.modules?.[0]?.object?.document?.url ?? null
+  const doc = story.contents?.modules?.[0]?.object?.document ?? null
+  if (!doc) return null
+  const videoUrl =
+    doc.data.translated_urls && typeof doc.data.translated_urls === 'string'
+      ? doc.data.translated_urls
+      : doc.url
   return (
     <div className={styles.PeriodVideoBox}>
       <Video url={videoUrl} ref={ref} />


### PR DESCRIPTION
Fix video urls in the perspective timelines (default URL doesn't take into account `translated_urls` property